### PR TITLE
Implement type hints for most functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
-# Change Log
+# Changelog
 
 All notable changes to this project will be documented here.
+
+## [3.0.0] - 2024-05-14
+### Added
+- Type hints for most functions
+### Changed
+- Now requires Python 3.11+
 
 ## [2.0.0] - 2019-10-14
 ### Changed

--- a/README.md
+++ b/README.md
@@ -14,19 +14,29 @@ In order to handle pagination calls to API are done inside a generator.
 As a consequence, even post and deletes have to be "nexted" if using the *hit_*
 method.
 
+## Requirements
+
+Pythom 3.11+, `2.0.0` was the last version to support Python 2.7-3.10
+
 ## Installation
 
-The package can be installed cloning the repository and doing
-`python setup.py install` or `pip install .`.
+Using PyPI into a [venv](https://docs.python.org/3/library/venv.html):
+```bash
+pip install python-helpscout-v2 --require-virtualenv`
+```
 
-It can also be install from pypi.org doing `pip install python-helpscout-v2`.
+Manually by cloning the repository and executing pip into a [venv](https://docs.python.org/3/library/venv.html):
+```bash
+pip install . --require-virtualenv`
+```
+
 
 ## Authentication
 
 In order to use the API you need an app id and app secret.
 
 More about credentials can be found in
-[helpscout's documentation](https://developer.helpscout.com/mailbox-api/overview/authentication/).
+[Help Scout's documentation](https://developer.helpscout.com/mailbox-api/overview/authentication/).
 
 ## General use
 

--- a/helpscout/client.py
+++ b/helpscout/client.py
@@ -1,9 +1,11 @@
+# 3.13 defaults to this, TODO remove
+from __future__ import annotations
+
 import logging
 import time
 import requests
 import typing
 
-#import helpscout
 if typing.TYPE_CHECKING:
     from collections.abc import Generator
 
@@ -55,7 +57,7 @@ class HelpScout:
         self.rate_limit_sleep = rate_limit_sleep
         self.access_token = None
 
-    def __getattr__(self, endpoint:str) -> 'HelpScoutEndpointRequester':
+    def __getattr__(self, endpoint:str) -> HelpScoutEndpointRequester:
         """Returns a request to hit the API in a nicer way. E.g.:
         > client = HelpScout(app_id='asdasd', app_secret='1021')
         > client.conversations.get()
@@ -138,7 +140,7 @@ class HelpScout:
         """
         return list(self.hit_(endpoint, method, resource_id, data, params))
 
-    def hit_(self, endpoint:str, method:str, resource_id:int|str|None=None, data:dict|None=None, params:dict|str|None=None) -> 'Generator[dict|None, None, None]':
+    def hit_(self, endpoint:str, method:str, resource_id:int|str|None=None, data:dict|None=None, params:dict|str|None=None) -> Generator[dict|None, None, None]:
         """Hits the api and yields the data.
 
         Parameters
@@ -196,7 +198,7 @@ class HelpScout:
         else:
             raise HelpScoutException(r.text)
 
-    def _results_with_pagination(self, response:dict, method:str) -> 'Generator[dict, None, None]':
+    def _results_with_pagination(self, response:dict, method:str) -> Generator[dict, None, None]:
         """Requests and yields pagination results.
 
         Parameters
@@ -324,7 +326,7 @@ class HelpScoutEndpointRequester:
         self.endpoint = endpoint
         self.specific_resource = specific_resource
 
-    def __getattr__(self, method:str) -> 'partial | HelpScoutEndpointRequester':
+    def __getattr__(self, method:str) -> partial | HelpScoutEndpointRequester:
         """Catches http methods like get, post, patch, put and delete.
         Returns a subrequester when methods not named after http methods are
         requested, as this are considered attributes of the main object, like
@@ -359,7 +361,7 @@ class HelpScoutEndpointRequester:
                 False,
                 )
 
-    def __getitem__(self, resource_id:int|str) -> 'HelpScoutEndpointRequester':
+    def __getitem__(self, resource_id:int|str) -> HelpScoutEndpointRequester:
         """Returns a second endpoint requester extending the endpoint to a
         specific resource_id or resource_name.
 

--- a/helpscout/client.py
+++ b/helpscout/client.py
@@ -259,6 +259,8 @@ class HelpScout:
 
     def _authentication_headers(self):
         """Returns authentication headers."""
+        if self.access_token is None:
+            raise HelpScoutAuthenticationException('Tried to get access_token without prior authentication')
         return {
             'Authorization': 'Bearer ' + self.access_token,
             'content-type': 'application/json',

--- a/helpscout/client.py
+++ b/helpscout/client.py
@@ -138,7 +138,7 @@ class HelpScout:
         """
         return list(self.hit_(endpoint, method, resource_id, data, params))
 
-    def hit_(self, endpoint:str, method:str, resource_id:int|str|None=None, data:dict|None=None, params:dict|str|None=None) -> Generator[dict|None, None, None]:
+    def hit_(self, endpoint:str, method:str, resource_id:int|str|None=None, data:dict|None=None, params:dict|str|None=None) -> 'Generator[dict|None, None, None]':
         """Hits the api and yields the data.
 
         Parameters
@@ -196,7 +196,7 @@ class HelpScout:
         else:
             raise HelpScoutException(r.text)
 
-    def _results_with_pagination(self, response:dict, method:str) -> Generator[dict, None, None]:
+    def _results_with_pagination(self, response:dict, method:str) -> 'Generator[dict, None, None]':
         """Requests and yields pagination results.
 
         Parameters

--- a/helpscout/client.py
+++ b/helpscout/client.py
@@ -394,7 +394,7 @@ class HelpScoutEndpointRequester:
             True,
             )
 
-    def _yielded_function(self, method, *args, **kwargs):
+    def _yielded_function(self, method:str, *args, **kwargs):
         """Calls a generator function and calls next.
         It is intended to be used with post, put, patch and delete which do not
         return objects, but as hit is a generator, still have to be nexted.
@@ -405,6 +405,8 @@ class HelpScoutEndpointRequester:
             Positional arguments after *method* to forward to client.hit .
         *kwargs: keyword arguments
             Keyword arguments after *method* to forward to client.hit.
+        method: str
+            Inherited
 
         Returns
         -------

--- a/helpscout/client.py
+++ b/helpscout/client.py
@@ -5,8 +5,10 @@ import logging
 import time
 import requests
 import typing
+from typing import overload
 
 if typing.TYPE_CHECKING:
+    from typing import Callable, Literal
     from collections.abc import Generator
 
 from functools import partial
@@ -326,7 +328,13 @@ class HelpScoutEndpointRequester:
         self.endpoint = endpoint
         self.specific_resource = specific_resource
 
-    def __getattr__(self, method:str) -> partial | HelpScoutEndpointRequester:
+    @overload
+    def __getattr__(self, method: Literal['get']) -> Callable: ...
+
+    @overload
+    def __getattr__(self, method:str) -> Callable | partial | HelpScoutEndpointRequester: ...
+
+    def __getattr__(self, method:str) -> Callable | partial | HelpScoutEndpointRequester:
         """Catches http methods like get, post, patch, put and delete.
         Returns a subrequester when methods not named after http methods are
         requested, as this are considered attributes of the main object, like
@@ -339,8 +347,8 @@ class HelpScoutEndpointRequester:
 
         Returns
         -------
-        client.get_objects return value for the *get* method.
-        client.hit return value for other http named methods.
+        Callable - client.get_objects return value for the *get* method.
+        partial - client.hit return value for other http named methods.
         HelpScoutEndpointRequester when other attributes are accessed, this is
           expected to be used mainly for subattributes of an endpoint or
           subendpoints of specific resources, like tags from a conversation.

--- a/helpscout/model.py
+++ b/helpscout/model.py
@@ -1,3 +1,6 @@
+# 3.13 defaults to this, TODO remove
+from __future__ import annotations
+
 class HelpScoutObject(object):
 
     key = ''
@@ -24,7 +27,7 @@ class HelpScoutObject(object):
             setattr(self, key, value)
 
     @classmethod
-    def from_results(cls, api_results) -> 'list[HelpScoutObject]':
+    def from_results(cls, api_results) -> list[HelpScoutObject]:
         """Generates HelpScout objects from API results.
 
         Parameters

--- a/helpscout/model.py
+++ b/helpscout/model.py
@@ -2,8 +2,8 @@ class HelpScoutObject(object):
 
     key = ''
 
-    def __init__(self, api_object):
-        """Object build from an API dictionary.
+    def __init__(self, api_object:dict):
+        """Object built from an API dictionary.
         Variable assignments to initialized objects is not expected to be done.
 
         Parameters
@@ -24,18 +24,18 @@ class HelpScoutObject(object):
             setattr(self, key, value)
 
     @classmethod
-    def from_results(cls, api_results):
+    def from_results(cls, api_results) -> 'list[HelpScoutObject]':
         """Generates HelpScout objects from API results.
 
         Parameters
         ----------
         api_results: generator({cls.key: [dict]}) or generator(dict)
-            A generator returning API responses that cointain a list of
+            A generator returning API responses that contain a list of
             objects each under the class key.
 
         Returns
         -------
-        [HelpScoutObject]
+        list[HelpScoutObject]
         """
         results = []
         for api_result in api_results:
@@ -45,7 +45,7 @@ class HelpScoutObject(object):
         return results
 
     @classmethod
-    def cls(cls, entity_name, key):
+    def cls(cls, entity_name:str, key:str):
         """Returns the object class based on the entity_name.
 
         Parameters
@@ -77,7 +77,7 @@ class HelpScoutObject(object):
         globals()[class_name] = cls = type(class_name, (cls,), {'key': key})
         return cls
 
-    def __setattr__(self, attr, value):
+    def __setattr__(self, attr:str, value:object):
         """Sets an attribute to an object and adds it to the attributes list.
 
         Parameters
@@ -108,7 +108,7 @@ class HelpScoutObject(object):
         for attr, value in zip(self._attrs, state[1]):
             setattr(self, attr, value)
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         """Equality comparison."""
         if self.__class__ is not other.__class__:
             return False
@@ -130,7 +130,7 @@ class HelpScoutObject(object):
         values = tuple(getattr(self, attr) for attr in self._attrs)
         return hash(self._attrs + flatten(values))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Returns the object as a string."""
         name = self.__class__.__name__
         attrs = self._attrs
@@ -145,13 +145,15 @@ class HelpScoutObject(object):
     __str__ = __repr__
 
 
-def get_subclass_instance(class_name, key):
+def get_subclass_instance(class_name: str, key):
     """Gets a dynamic class from a class name for unpickling.
 
     Parameters
     ----------
-    name: str
+    class_name: str
         A class name, expected to start with Upper case.
+    key: ???
+        TODO Missing desc
 
     Returns
     -------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.21.0
+requests~=2.31.0

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup(
     classifiers=[
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 3'
-        ]
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12'
+    ]
 )


### PR DESCRIPTION
Implemented type hints. Couple are missing, but most functions are covered.

Requires Python 3.11+, so I took it upon myself to tag a 3.0.0 version in the changelog, as 2.0.0 supports 2.7+.

Fixed some wrong documentation types and names.

Removed `python setup.py` install instructions and added venv req flag to pip calls.

Also bumps up the requests dependency, so this supersedes #6.
